### PR TITLE
Fix double use Str

### DIFF
--- a/src/Entrust/Traits/EntrustUserTrait.php
+++ b/src/Entrust/Traits/EntrustUserTrait.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Illuminate\Support\Str;
 
 trait EntrustUserTrait
 {


### PR DESCRIPTION
fix laravel error 

```
Symfony\Component\ErrorHandler\Error\FatalError
Cannot use Illuminate\Support\Str as Str because the name is already in use
```